### PR TITLE
Add a full_title helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+
+  def full_title(page_title = '')
+    base_title = "Ruby on Rails Tutorial Sample App"
+    if page_title.empty?
+      base_title
+    else
+      "#{page_title} | #{base_title}"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta charset="utf-8">
     <%= csrf_meta_tags %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,3 @@
-<% provide(:title, "Home") %>
 <h1>Sample App</h1>
 <p>
   This is the home page for the

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -2,33 +2,21 @@ require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
 
-  def setup
-    @base_title = "Ruby on Rails Tutorial Sample App"
-  end
-
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home | #{@base_title}"
+    assert_select "title", "Ruby on Rails Tutorial Sample App"
   end
 
   test "should get help" do
     get static_pages_help_url
     assert_response :success
-    assert_select "title", "Help | #{@base_title}"
+    assert_select "title", "Help | Ruby on Rails Tutorial Sample App"
   end
 
   test "should get about" do
     get static_pages_about_url
     assert_response :success
-    assert_select "title", "About | #{@base_title}"
+    assert_select "title", "About | Ruby on Rails Tutorial Sample App"
   end
-
-  test 'should get contact' do
-    get static_pages_contact_url
-    assert_response :success
-    assert_select "title", "Contact | #{@base_title}"
-  end
-
-  
 end


### PR DESCRIPTION
### やったこと
- Railsアプリケーションのレイアウトを設定し、組み込み関数とカスタムヘルパーを利用した。
- `stylesheet_link_tag` 組み込み関数を使用してスタイルシートを適用。
- カスタムヘルパー `full_title` を作成してページタイトルを動的に設定。
- タイトルをテストするコードを実装し、テストをパスさせた。

### やらないこと
- 紙幅の関係で、`rails test` の実行結果の一部は省略される。

### できるようになること（ユーザ目線）
- ウェブページのタイトルが各ページに応じて適切に表示される。
  
### できなくなること（ユーザ目線）
- 余分なタイトルや縦棒（|）が表示されることはなくなる。

### 動作確認
- タイトルに関する自動テストが成功している。
  
### その他
- 本章では、Rubyの多数の基本概念（モジュール、メソッド定義、任意のメソッド引数、コメント、ローカル変数の割り当て、論理値、制御フロー、文字列の式展開、戻り値）も学習した。
- ページのレイアウトについても、Railsの組み込み機能を利用して効率良く設定できた。
