### PR TITLE
Advanced login

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -183,6 +183,20 @@ input {
   }
 }
 
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}
+
 /* Dropdown menu */
 
 .dropdown-menu.active {

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,8 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-      reset_session      
+      reset_session 
+      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
       log_in user
       redirect_to user
     else
@@ -16,7 +17,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url, status: :see_other
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -5,10 +5,23 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
-  # 現在ログイン中のユーザーを返す（いる場合）
+  # 永続的セッションのためにユーザーをデータベースに記憶する
+  def remember(user)
+    user.remember
+    cookies.permanent.encrypted[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  # 記憶トークンcookieに対応するユーザーを返す
   def current_user
-    if session[:user_id]
-      @current_user ||= User.find_by(id: session[:user_id])
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.encrypted[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
     end
   end
 
@@ -17,9 +30,17 @@ module SessionsHelper
     !current_user.nil?
   end
 
+  # 永続的セッションを破棄する
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   # 現在のユーザーをログアウトする
   def log_out
+    forget(current_user)
     reset_session
-    @current_user = nil   # 安全のため
+    @current_user = nil
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  attr_accessor :remember_token
   before_save { self.email = email.downcase }
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
@@ -13,5 +14,27 @@ class User < ApplicationRecord
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
+  end
+
+  # ランダムなトークンを返す
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  # 永続的セッションのためにユーザーをデータベースに記憶する
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
+  end
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    return false if remember_digest.nil?
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
+
+  # ユーザーのログイン情報を破棄する
+  def forget
+    update_attribute(:remember_digest, nil)
   end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,6 +11,11 @@
       <%= f.label :password %>
       <%= f.password_field :password, class: 'form-control' %>
 
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+        <%= f.check_box :remember_me %>
+        <span>Remember me on this computer</span>
+      <% end %>
+
       <%= f.submit "Log in", class: "btn btn-primary" %>
     <% end %>
 

--- a/db/migrate/20230904084613_add_remember_digest_to_users.rb
+++ b/db/migrate/20230904084613_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_27_091233) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_04_084613) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -5,20 +5,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   def setup
     @user = users(:michael)
   end
-
-  test "login with valid email/invalid password" do
-    get login_path
-    assert_template 'sessions/new'
-    post login_path, params: { session: { email:    @user.email,
-                                          password: "invalid" } }
-    assert_not is_logged_in?
-    assert_response :unprocessable_entity
-    assert_template 'sessions/new'
-    assert_not flash.empty?
-    get root_path
-    assert flash.empty?
-  end
-
+  
   test "login with valid information followed by logout" do
     post login_path, params: { session: { email:    @user.email,
                                           password: 'password' } }
@@ -30,12 +17,28 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path
     assert_select "a[href=?]", user_path(@user)
     delete logout_path
-    assert_not is_logged_in?
     assert_response :see_other
+    assert_not is_logged_in?
     assert_redirected_to root_url
+    # 2番目のウィンドウでログアウトをクリックするユーザーをシミュレートする
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+
+  test "login with remembering" do
+    log_in_as(@user, remember_me: '1')
+    assert_not cookies[:remember_token].blank?
+  end
+
+  test "login without remembering" do
+    # Cookieを保存してログイン
+    log_in_as(@user, remember_me: '1')
+    # Cookieが削除されていることを検証してからログイン
+    log_in_as(@user, remember_me: '0')
+    assert cookies[:remember_token].blank?
+  end
+  
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -36,4 +36,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = "a" * 5
     assert_not @user.valid?
   end
+
+  test "authenticated? should return false for a user with nil digest" do
+    assert_not @user.authenticated?('')
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,4 +12,19 @@ class ActiveSupport::TestCase
   def is_logged_in?
     !session[:user_id].nil?
   end
+
+  # テストユーザーとしてログインする
+  def log_in_as(user)
+    session[:user_id] = user.id
+  end
+end
+
+class ActionDispatch::IntegrationTest
+
+  # テストユーザーとしてログインする
+  def log_in_as(user, password: 'password', remember_me: '1')
+    post login_path, params: { session: { email: user.email,
+                                          password: password,
+                                          remember_me: remember_me } }
+  end
 end


### PR DESCRIPTION
### やったこと

- ユーザーがウェブサイトを移動する際に状態（例：ログイン状態）を保持する仕組みを`session`を用いて実装した。
- 長期間状態を保持するために、`cookies`を使って永続的セッションを実現した。
- それぞれのユーザーに対して、独自の記憶トークンと記憶ダイジェストを生成し、これを関連付けることでセキュアな永続的セッションを確立した。
- ログアウト機能を実装し、`session`および`cookies`を削除することでログアウトを実現した。
- コードの可読性を高めるために、三項演算子を使って単純なif-then文をコンパクトに記述した。

### やらないこと

- 二要素認証やOAuthによるサードパーティログイン（Google、Facebookなど）は今回は実装しない。
- パスワード変更やアカウント復旧の仕組みも今回は取り上げていない。

### できるようになること（ユーザ目線）

- ユーザーはログイン後、サイト内を自由に移動でき、その状態が保持される。
- 「ログイン状態を保持する」を選ぶことで、次回から自動的にログインされる（永続的セッション）。
- ユーザーは必要な場合に安全にログアウトができる。

### できなくなること（ユーザ目線）

- ログアウト後、以前の状態（例：カートに入れた商品など）は保持されない。

### 動作確認

- 新規ユーザーがサインアップできること。
- ユーザーがログイン・ログアウトできること。
- ユーザーがログインした状態でサイト内を移動しても状態が保持されること。
- 「ログイン状態を保持する」を選んだ場合、ブラウザを閉じても再度開いたときにログイン状態が維持されていること。

### その他

- セキュリティ強化のため、記憶トークンと記憶ダイジェストは暗号化して保存しています。
- 今後のバージョンアップで、二要素認証やパスワード変更機能などを追加予定です。
